### PR TITLE
Serverless upgrade

### DIFF
--- a/TECH_DEBTS.md
+++ b/TECH_DEBTS.md
@@ -16,7 +16,7 @@
 1. Refactor conflicts identifier class
 1. Add tests on setting and schedule type accordance
 1. Add check for invalid cron pair in schedule
-1. Upgrade serverless framework version
+1. ~~Upgrade serverless framework version~~
 1. Export DDB request parameters builder functions for create and delete requests to db helper 
 
 ##### Web

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -4,3 +4,5 @@ jspm_packages
 
 # Serverless directories
 .serverless
+
+.env

--- a/api/README.md
+++ b/api/README.md
@@ -66,3 +66,4 @@ Used plugins:
 * [serverless-dynamodb-local](https://github.com/99xt/serverless-dynamodb-local)
 * [serverless-dynamodb-client](https://github.com/99xt/serverless-dynamodb-client)
 * [serverless-mocha-plugin](https://github.com/SC5/serverless-mocha-plugin)
+* [serverless-export-env](https://github.com/arabold/serverless-export-env)

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1140,6 +1140,10 @@
       "integrity": "sha512-rmBLMbj0WD9iY5PMIvvGbX4gcGFWUGR96aOdoVGTG0mY+oMulsnHFidOAMXIhSsI2lQREMu16Ly2aUagGFWUNw==",
       "dev": true
     },
+    "serverless-export-env": {
+      "version": "github:arabold/serverless-export-env#a3625746225307eb22abe4a0426f00b5da7e0e4f",
+      "dev": true
+    },
     "serverless-mocha-plugin": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/serverless-mocha-plugin/-/serverless-mocha-plugin-1.5.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "serverless-dynamodb-local": "0.2.24",
+    "serverless-export-env": "github:arabold/serverless-export-env",
     "serverless-mocha-plugin": "1.5.1",
     "serverless-offline": "3.15.3"
   }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -39,6 +39,7 @@ plugins:
   - serverless-dynamodb-local
   - serverless-offline
   - serverless-mocha-plugin
+  - serverless-export-env
 
 resources:
   Resources: ${self:custom.resources}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -1,6 +1,6 @@
 service: screen-driver-api
 
-frameworkVersion: ">=1.1.0 <2.0.0"
+frameworkVersion: ">=1.20.1 <2.0.0"
 
 provider:
   name: aws

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -48,12 +48,7 @@ package:
   exclude:
     - docker/**
     - test/**
-    - .dockerignore
-    - package.json
-    - package-lock.json
+    - serverless/**
+    - .*
+    - package*
     - README.md
-    - node_modules/serverless-dynamodb-local/**
-    - node_modules/dynamodb-localhost/**
-    - node_modules/serverless-mocha-plugin/**
-    - node_modules/mocha/**
-    - node_modules/serverless-offline/**


### PR DESCRIPTION
Upgrade Serverless Framework version to 1.20.1 and add `serverless-export-env` plugin for work with CloudFormation variables locally. 
Perform `npm install -g serverless@1.20.1` to upgrade SF on local machine